### PR TITLE
add support for pvresize

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # ahuffman.lvm
 Configures Logical Volume Groups, Logical Volumes, Filesystems, mount points, and fstab.
 
+## Requirements
+
+* `ansible>=2.9`
+* `community.general>=0.2.0` collection; use either methods below to install it
+  * `ansible-galaxy collection install community.general`
+  * add following to `requirements.yml`
+    ```
+    collections:
+      - name: community.general
+    ```
+
 ## Variables
 |Variable Name|Description|Required|Default Value|Type|
 |---|---|:---:|:---:|:---:|

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
   # - CC-BY
   license: "MIT"
 
-  min_ansible_version: "2.4"
+  min_ansible_version: "2.9"
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 #Probe pv partitions to detect size changes
 - name: "Probe partitions"
-  parted:
+  community.general.parted:
     device: "{{ item.1 }}"
     unit: GB
   with_subelements:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,22 @@
 ---
+#Probe pv partitions to detect size changes
+- name: "Probe partitions"
+  parted:
+    device: "{{ item.1 }}"
+    unit: GB
+  with_subelements:
+    - "{{ lvm_vgs }}"
+    - pvs
+  loop_control:
+    label: "{{ item.1 }}"
+  become: True
+
 #Create volume group
 - name: "Ensure Logical Volume Group exists"
-  lvg:
+  community.general.lvg:
     vg: "{{ item.vg }}"
     pvs: "{{ item.pvs | join(',') }}"
+    pvresize: true
     state: "present"
   with_items:
     - "{{ lvm_vgs }}"


### PR DESCRIPTION
Adds support for resizing the physical volume by using a combination of probing the partition to detect size changes and then running the `lvg` module with `pvresize`.

The `pvresize` option is only available in the `community.general` collection requiring a more up to date Ansible (>`2.9`).